### PR TITLE
modify dropdown selectors and prevent conflicts with bootstrap 5+

### DIFF
--- a/bundle/Resources/es6/location.js
+++ b/bundle/Resources/es6/location.js
@@ -356,7 +356,7 @@ $(function () {
   });
 
   $(document).on('click', (e) => {
-    if ($(e.target).closest('.dropdown-menu').length === 0 && $(e.target).closest('.layout-dropdown').length === 0) {
+    if ($(e.target).closest('.dropdown-menu').length === 0 && $(e.target).closest('.dropdown').length === 0 && !($(e.target).dataset.bsToggle === "dropdown")) {
       $('.dropdown-menu').removeClass('show');
       $('.layout-dropdown').removeClass('show');
     }


### PR DESCRIPTION
`.layout-dropdown` class is only ever used in conjunction with `.dropdown`, but it was inadvertently causing issues with other packages which did not use `layout-dropdown` class

To fix this, `layout-dropdown` selector was changed to `dropdown`, which is the default bootstrap class

Along with this, added another condition that targets only bootstrap 5+ using `data-bs-toggle` parameter, which replaced `data-toggle`; In versions 5+, bootstrap implemented automatic dropdown closing and configuration through data parameters, rendering this snippet of code unnecessary for those versions, and this condition should prevent that.