### PR TITLE
IOTASUPP-23 hotfix global selector for closing dropdowns

### DIFF
--- a/bundle/Resources/es6/location.js
+++ b/bundle/Resources/es6/location.js
@@ -357,7 +357,7 @@ $(function () {
   });
 
   $(document).on('click', (e) => {
-    if ($(e.target).closest('.dropdown-menu').length === 0 && $(e.target).closest('.layout-dropdown').length === 0) {
+    if ($(e.target).closest('.dropdown').length === 0 && $(e.target).closest('.layout-dropdown').length === 0 && !($(e.target).dataset.bsToggle === 'dropdown')) {
       $('.dropdown-menu').removeClass('show');
       $('.layout-dropdown').removeClass('show');
     }


### PR DESCRIPTION
This PR is a duplicate of https://github.com/netgen-layouts/layouts-ibexa/pull/11, but with applied CS fixes and a bit different logic.

Original PR claims:
_.layout-dropdown class is only ever used in conjunction with .dropdown, but it was inadvertently causing issues with other packages which did not use layout-dropdown class

To fix this, layout-dropdown selector was changed to dropdown, which is the default bootstrap class_

@RobertK0 layout-dropdown class was not the issue here, but .dropdown-menu -> changing it to .dropdown fixes the problem for global dropdowns. The issue is related to the click target element. When this is used in NG Layouts context, we have a clickable button wrapped inside "layout-dropdown dropdown" container. But in global context, the condition ($(e.target).closest('.dropdown-menu').length === 0 is always satisfied for any clickable element on the page, as the dropdown toggle button is never wrapped inside "dropdown-menu" container, and the closest() selector always look up the DOM tree. So this will automatically apply to any button clicked anywhere on the page, and it will globally close all open dropdown-menu elements on the page. Which was the actual cause of the issue -  you would click the button to open the dropdown menu, and the global click event would automatically close it :)


Along with this, added another condition that targets only bootstrap 5+ using data-bs-toggle parameter, which replaced data-toggle; In versions 5+, bootstrap implemented automatic dropdown closing and configuration through data parameters, rendering this snippet of code unnecessary for those versions, and this condition should prevent that.

