### PR TITLE
Fix TypeError when closing dropdowns on document click

### DIFF
--- a/bundle/Resources/es6/location.js
+++ b/bundle/Resources/es6/location.js
@@ -357,7 +357,7 @@ $(function () {
   });
 
   $(document).on('click', (e) => {
-    if ($(e.target).closest('.dropdown').length === 0 && $(e.target).closest('.layout-dropdown').length === 0 && !($(e.target).dataset.bsToggle === 'dropdown')) {
+    if ($(e.target).closest('.dropdown').length === 0 && $(e.target).closest('.layout-dropdown').length === 0 && !(e.target.dataset.bsToggle === 'dropdown')) {
       $('.dropdown-menu').removeClass('show');
       $('.layout-dropdown').removeClass('show');
     }


### PR DESCRIPTION
## Title
Fix dropdown close handler TypeError on document click

## Summary
- Prevents `Cannot read properties of undefined (reading 'bsToggle')` when clicking outside dropdowns
- Uses `e.target.dataset.bsToggle` instead of attempting to read `dataset` from a jQuery object
- Keeps existing “click outside closes dropdown” behavior intact

## Why
The handler was accessing `$(e.target).dataset.bsToggle`, but jQuery-wrapped elements don’t expose `dataset`, causing a runtime error on non-dropdown clicks.

## Test plan
- Click outside any dropdown → no console error; any open dropdowns close
- Click inside a `.dropdown` / `.layout-dropdown` → dropdown interaction still works
- Click a dropdown toggle (`data-bs-toggle="dropdown"`) → toggle works; no console error

## Scope
- Files changed: `bundle/Resources/es6/location.js`